### PR TITLE
Add support for PyPy3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.2
+current_version = 0.6.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: TOX_ENV=py35
     - python: "3.6"
       env: TOX_ENV=py36
+    - python: "pypy3"
+      env: TOX_ENV=pypy3
     - python: "3.6"
       env: TOX_ENV=flake8
 cache:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Ethereum Bloom Filter
 
+[![Build Status](https://travis-ci.org/ethereum/eth-bloom.svg?branch=master)](https://travis-ci.org/ethereum/eth-bloom)
+[![PyPI version](https://badge.fury.io/py/eth-bloom.svg)](https://badge.fury.io/py/eth-bloom)
+[![Python versions](https://img.shields.io/pypi/pyversions/eth-bloom.svg)](https://pypi.python.org/pypi/eth-bloom)
+
 A python implementation of the bloom filter used by Ethereum.
 
 > This library and repository was previously located at https://github.com/pipermerriam/ethereum-bloom.  It was transferred to the Ethereum foundation github in November 2017 and renamed to `eth-bloom`.  The PyPi package was also renamed from `ethereum-bloom` to `eth-bloom.

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -4,13 +4,7 @@ import numbers
 import operator
 import sys
 
-try:
-    from sha3 import keccak_256
-except ImportError:
-    from sha3 import sha3_256 as keccak_256
-
-
-assert keccak_256(b'').digest() == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04\x5d\x85\xa4p", "Incorrect sha3.  Make sure it's keccak"  # noqa: E501
+from .crypto import keccak_256
 
 
 if sys.version_info.major == 3:

--- a/eth_bloom/crypto.py
+++ b/eth_bloom/crypto.py
@@ -1,0 +1,13 @@
+from Crypto.Hash import keccak
+
+
+class keccak_256:
+    def __init__(self, value):
+        self.hash = keccak.new(digest_bits=256)
+        self.hash.update(value)
+
+    def digest(self):
+        return self.hash.digest()
+
+
+assert keccak_256(b'').digest() == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04\x5d\x85\xa4p", "Incorrect sha3.  Make sure it's keccak"  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 setup(
     name='eth-bloom',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version='0.5.2',
+    version='0.6.0',
     description="""Python implementation of the Ethereum Trie structure""",
     long_description_markdown_filename='README.md',
     author='Piper Merriam',

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     py_modules=['eth_bloom'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "pysha3>=0.3",
+        "pycryptodome>=3.4.6",
     ],
     license="MIT",
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35,36}
+    py27,py34,py35,py36,pypy,pypy3
     flake8
 
 [flake8]
@@ -18,6 +18,8 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    pypy: pypy
+    pypy3: pypy3
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
### What was wrong?

`pysha3`, a dependency of `eth-bloom` fails to compile under PyPy3. [Here](https://bitbucket.org/pypy/pypy/issues/2687/pypy3-is-missing-pystrhexh-breaking-pysha3) is the relevant issue on PyPy's Bitbucket.

Subsequently, all packages relying on `eth-bloom` had no support for PyPy3. See this issue on PyEVM project: https://github.com/ethereum/py-evm/issues/138

### How was it fixed?

I swapped out [pysha3](https://github.com/tiran/pysha3) with [PyCryptodome](https://www.pycryptodome.org), which provides `keccak` implementations compatible across major Python versions, most notably PyPy3.

#### Cute Animal Picture

![Cute animal picture](https://tinierthings.files.wordpress.com/2013/04/cuteanimalanimalspuppy.jpg)
