### PR TITLE
Housekeeping: py2 cruft, circleci tests, etc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: lint
+  py34-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.4
+        environment:
+          TOXENV: py34
+  py35-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35
+  py36-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36
+  pypy3-core:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3
+workflows:
+  version: 2
+  test:
+    jobs:
+      - lint
+      - py34-core
+      - py35-core
+      - py36-core
+      - pypy3-core

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info
 dist
 build
+.eggs
 eggs
 parts
 var
@@ -52,3 +53,6 @@ prof/**
 
 # Hypothesis
 .hypothesis/**
+
+# Virtualenv
+venv*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ matrix:
       env: TOX_ENV=py35
     - python: "3.6"
       env: TOX_ENV=py36
+    - python: "pypy3.5"
+      env: TOX_ENV=pypy3
     - python: "3.6"
       env: TOX_ENV=flake8
-    - python: "pypy3"
-      env: TOX_ENV=pypy3
 cache:
   - pip: true
   - directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - python: "pypy3.5"
       env: TOX_ENV=pypy3
     - python: "3.6"
-      env: TOX_ENV=flake8
+      env: TOX_ENV=lint
 cache:
   - pip: true
   - directories:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 eth_bloom
+	flake8 eth_bloom tests
 
 test:
 	py.test --tb native tests

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -2,13 +2,8 @@ from __future__ import absolute_import
 
 import numbers
 import operator
-import sys
 
 from eth_hash.auto import keccak as keccak_256
-
-
-if sys.version_info.major == 3:
-    long = int
 
 
 def get_chunks_for_bloom(value_hash):
@@ -67,7 +62,7 @@ class BloomFilter(numbers.Number):
         return operator.index(self.value)
 
     def _combine(self, other):
-        if not isinstance(other, (int, long, BloomFilter)):
+        if not isinstance(other, (int, BloomFilter)):
             raise TypeError(
                 "The `or` operator is only supported for other `BloomFilter` instances"
             )
@@ -80,7 +75,7 @@ class BloomFilter(numbers.Number):
         return self._combine(other)
 
     def _icombine(self, other):
-        if not isinstance(other, (int, long, BloomFilter)):
+        if not isinstance(other, (int, BloomFilter)):
             raise TypeError(
                 "The `or` operator is only supported for other `BloomFilter` instances"
             )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ tox==2.6.0
 pytest==3.0.7
 hypothesis==3.7.0
 bumpversion==0.5.3
+flake8>=3.5.0,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_bloom_filter.py
+++ b/tests/test_bloom_filter.py
@@ -5,6 +5,7 @@ import itertools
 from hypothesis import (
     strategies as st,
     given,
+    settings,
 )
 from eth_bloom import (
     BloomFilter,
@@ -28,6 +29,7 @@ def check_bloom(bloom, log_entries):
 
 
 @given(log_entries)
+@settings(max_examples=20000)
 def test_bloom_filter_add_method(log_entries):
     bloom = BloomFilter()
 
@@ -40,6 +42,7 @@ def test_bloom_filter_add_method(log_entries):
 
 
 @given(log_entries)
+@settings(max_examples=20000)
 def test_bloom_filter_extend_method(log_entries):
     bloom = BloomFilter()
 
@@ -51,6 +54,7 @@ def test_bloom_filter_extend_method(log_entries):
 
 
 @given(log_entries)
+@settings(max_examples=20000)
 def test_bloom_filter_from_iterable_method(log_entries):
     bloomables = itertools.chain.from_iterable(
         itertools.chain([address], topics)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35,36,py3}
+    py{34,35,36,py3}
     flake8
 
 [flake8]
@@ -15,7 +15,6 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     eth-hash[pycryptodome]
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{34,35,36,py3}
-    flake8
+    lint
 
 [flake8]
 max-line-length= 100
@@ -20,7 +20,7 @@ basepython =
     py36: python3.6
     pypy3: pypy3
 
-[testenv:flake8]
+[testenv:lint]
 basepython=python
 deps=flake8
 commands=flake8 {toxinidir}/eth_bloom

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ basepython =
 [testenv:lint]
 basepython=python
 deps=flake8
-commands=flake8 {toxinidir}/eth_bloom
+commands=flake8 {toxinidir}/eth_bloom {toxinidir}/tests


### PR DESCRIPTION
## Rebased after merging #16

This is now primarily a housekeeping PR:

- drop some old py2 support cruft
- run many more hypothesis examples, partially to monitor if pypy3 is any faster
- run flake8 on tests/ in tox (it was already passing) 
- add config to run circleci tests

## For Archival Purposes, this PR was originally:

### What was wrong?

See #12 - but we want a shared library so this change can be made easily across the python eth-* suite.

### How was it fixed?

- Depend on eth-hash
- Use pycryptodome in tests
- Add pypy3

It would be good to focus a bit on how and where the backends are specified:

#### Splitting eth-* into tiers

My idea is to split the eth-* ecosystem into three tiers that treat the eth-hash backends differently:
1. eth-hash needs to explicitly support all backends, but the base install doesn't require any of them
2. Utility libraries, like eth-bloom/eth-trie/etc, will require the base eth-hash install, which means they are *not* opinionated on the backend installed (except having to choose one during testing) -- this means that installing only eth-bloom and not any backends will trigger an error at runtime (with a helpful error message about how to install a backend)
3. End-user libraries, like web3.py/trinity/populus, can choose their own approach, that might look like one of these:
  a) force installation of a specific backend, by requiring `['eth-bloom', 'eth-hash[pysha3]']`
  b) support backends in its own extra, like `pip install web3[pysha3]`, where that extra would include a dependency on `eth-hash[pysha3]`
  c) install a backend at runtime if one is missing, with maybe a user prompt, cmd line flag, or env variable

#### What does that approach buy us?

This approach enables this solution when we want to spread a new backend across the ecosystem:
1. Upgrade eth-hash to add support for it (does not need to be a major version release)
2. eth-bloom/eth-trie/etc requires **no change**
3. end-user libraries like web3.py switch their backend in their own time, with their own approach

Thoughts on this goal and the solution?

#### Cute Animal Picture

![Cute animal picture](http://www.thetopfree.com/d/file/free-photos/animal/0924/images/furry-dog-people-animal-cute-about-animal-portrait-11558.jpg)