### PR TITLE
Integration with eth-hash package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: TOX_ENV=py36
     - python: "3.6"
       env: TOX_ENV=flake8
+    - python: "pypy3"
+      env: TOX_ENV=pypy3
 cache:
   - pip: true
   - directories:

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -4,13 +4,7 @@ import numbers
 import operator
 import sys
 
-try:
-    from sha3 import keccak_256
-except ImportError:
-    from sha3 import sha3_256 as keccak_256
-
-
-assert keccak_256(b'').digest() == b"\xc5\xd2F\x01\x86\xf7#<\x92~}\xb2\xdc\xc7\x03\xc0\xe5\x00\xb6S\xca\x82';\x7b\xfa\xd8\x04\x5d\x85\xa4p", "Incorrect sha3.  Make sure it's keccak"  # noqa: E501
+from eth_hash.auto import keccak as keccak_256
 
 
 if sys.version_info.major == 3:
@@ -29,7 +23,7 @@ def chunk_to_bloom_bits(chunk):
 
 
 def get_bloom_bits(value):
-    value_hash = keccak_256(value).digest()
+    value_hash = keccak_256(value)
     for chunk in get_chunks_for_bloom(value_hash):
         bloom_bits = chunk_to_bloom_bits(chunk)
         yield bloom_bits

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     py_modules=['eth_bloom'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "pysha3>=0.3",
+        "eth-hash[pycryptodome]>=0.1.*",
     ],
     license="MIT",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     py_modules=['eth_bloom'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-hash[pycryptodome]>=0.1.*",
+        "eth-hash>=0.1.0a3,<0.2.0",
     ],
     license="MIT",
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands=
     py.test {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
+    eth-hash[pycryptodome]
 basepython =
     py27: python2.7
     py34: python3.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35,36}
+    py{27,34,35,36,py3}
     flake8
 
 [flake8]
@@ -18,6 +18,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    pypy3: pypy3
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
### What was wrong?

Carrying over the work done in PR #12 here.

We recently released the [eth-hash](https://github.com/ethereum/eth-hash) package that contains multiple backends for computing `keccak256`, [pycryptodome](https://github.com/Legrandin/pycryptodome) being the default one.

The purpose of using `eth-hash` is to give users the freedom to choose their favorite crypto backend. In the context of `eth-bloom`, and all other Ethereum packages depending upon `pysha3`, this migration will automatically bring support for PyPy3.

### How was it fixed?

Replaced `pysha3` with `eth-hash` (`pycryptodome` backend).

#### Cute Animal Picture

![Cute animal picture](http://s-ak.buzzfeed.com/static/enhanced/web03/2011/8/8/23/enhanced-buzz-21498-1312861174-7.jpg)
