### PR TITLE
Bump eth-hash version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: python
 matrix:
   include:
-    - python: "3.4"
-      env: TOX_ENV=py34
     - python: "3.5"
       env: TOX_ENV=py35
     - python: "3.6"

--- a/eth_bloom/__init__.py
+++ b/eth_bloom/__init__.py
@@ -1,12 +1,7 @@
 import sys
-import warnings
 
 from .bloom import BloomFilter  # noqa: F401
 
 
-if sys.version_info.major < 3:
-    warnings.simplefilter('always', DeprecationWarning)
-    warnings.warn(DeprecationWarning(
-        "The `eth-bloom` library is dropping support for Python 2.  Upgrade to Python 3."
-    ))
-    warnings.resetwarnings()
+if sys.version_info < (3, 5):
+    raise EnvironmentError("Python 3.5 or above is requires")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     py_modules=['eth_bloom'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-hash>=0.1.0a3,<0.2.0",
+        "eth-hash>=0.1.0a3,<0.3.0",
     ],
     license="MIT",
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{34,35,36,py3}
+    py{35,36,py3}
     lint
 
 [flake8]
@@ -15,7 +15,6 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     eth-hash[pycryptodome]
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     pypy3: pypy3


### PR DESCRIPTION
### What was wrong?

web3.py requires eth-hash version >0.2.0 and eth-bloom <0.2.0

### How was it fixed?
Bump version ceiling in setup.py


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/8933231/45181475-6bd2e800-b1d3-11e8-9760-63160bf46aac.png)
