### PR TITLE
Add Type Hinting to eth_bloom

### DIFF
--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -4,7 +4,6 @@ import numbers
 import operator
 from typing import (
     Iterable,
-    Type,
     Union,
 )
 

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -4,9 +4,7 @@ import numbers
 import operator
 from typing import (
     Iterable,
-    Sequence,
     Type,
-    TypeVar,
     Union,
 )
 
@@ -31,9 +29,6 @@ def get_bloom_bits(value: bytes) -> Iterable[int]:
         yield bloom_bits
 
 
-T = TypeVar('T', bound='BloomFilter')
-
-
 class BloomFilter(numbers.Number):
     value = None
 
@@ -49,12 +44,12 @@ class BloomFilter(numbers.Number):
         for bloom_bits in get_bloom_bits(value):
             self.value |= bloom_bits
 
-    def extend(self, iterable: Sequence[bytes]) -> None:
+    def extend(self, iterable: Iterable[bytes]) -> None:
         for value in iterable:
             self.add(value)
 
     @classmethod
-    def from_iterable(cls: Type[T], iterable: Sequence[bytes]) -> T:
+    def from_iterable(cls, iterable: Iterable[bytes]) -> "BloomFilter":
         bloom = cls()
         bloom.extend(iterable)
         return bloom
@@ -71,20 +66,20 @@ class BloomFilter(numbers.Number):
     def __index__(self) -> int:
         return operator.index(self.value)
 
-    def _combine(self: T, other: Union[int, T]) -> T:
+    def _combine(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         if not isinstance(other, (int, BloomFilter)):
             raise TypeError(
                 "The `or` operator is only supported for other `BloomFilter` instances"
             )
         return type(self)(int(self) | int(other))
 
-    def __or__(self: T, other: Union[int, T]) -> T:
+    def __or__(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         return self._combine(other)
 
-    def __add__(self: T, other: Union[int, T]) -> T:
+    def __add__(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         return self._combine(other)
 
-    def _icombine(self: T, other: Union[int, T]) -> T:
+    def _icombine(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         if not isinstance(other, (int, BloomFilter)):
             raise TypeError(
                 "The `or` operator is only supported for other `BloomFilter` instances"
@@ -92,8 +87,8 @@ class BloomFilter(numbers.Number):
         self.value |= int(other)
         return self
 
-    def __ior__(self: T, other: Union[int, T]) -> T:
+    def __ior__(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         return self._icombine(other)
 
-    def __iadd__(self: T, other: Union[int, T]) -> T:
+    def __iadd__(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         return self._icombine(other)

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -4,7 +4,7 @@ import numbers
 import operator
 from typing import (
     Iterable,
-    List,
+    Sequence,
     Type,
     TypeVar,
     Union,
@@ -49,12 +49,12 @@ class BloomFilter(numbers.Number):
         for bloom_bits in get_bloom_bits(value):
             self.value |= bloom_bits
 
-    def extend(self, iterable: List[bytes]) -> None:
+    def extend(self, iterable: Sequence[bytes]) -> None:
         for value in iterable:
             self.add(value)
 
     @classmethod
-    def from_iterable(cls: Type[T], iterable: List[bytes]) -> T:
+    def from_iterable(cls: Type[T], iterable: Sequence[bytes]) -> T:
         bloom = cls()
         bloom.extend(iterable)
         return bloom

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ envlist=
 [flake8]
 max-line-length= 100
 exclude= tests/*
+commands=
+	mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p eth_bloom`
+
 
 [testenv]
 usedevelop=True

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ envlist=
 max-line-length= 100
 exclude= tests/*
 commands=
-	mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p eth_bloom`
-
+	mypy --strict --follow-imports=silent --ignore-missing-imports -p eth_bloom
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
### What was wrong?
There are no type hints for the `eth_bloom` module. This needs to be fixed.
Issue : #21 


### How was it fixed?
The type hints were added by having the insights of the code along with `assert` and `isinstance` statements.
The `eth_bloom/bloom.py` file and `tox.ini` file were updated.

#### Cute Animal Picture

![Cute animal picture](https://files.brightside.me/files/news/part_38/384510/preview-16750460-650x341-98-1509109344.jpg)
