### PR TITLE
Update tox, travis, setup.py and circleci to run tests on python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36
+  py37-core:
+    <<: *common
+    docker:
+    - image: circleci/python:3.7
+      environment:
+        TOXENV: py37
   pypy3-core:
     <<: *common
     docker:
@@ -62,4 +68,5 @@ workflows:
       - py34-core
       - py35-core
       - py36-core
+      - py37-core
       - pypy3-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,19 @@ matrix:
       env: TOX_ENV=py35
     - python: "3.6"
       env: TOX_ENV=py36
+    - python: "3.7"
+      env: TOX_ENV=py37
+      dist: xenial
+      sudo: true
     - python: "pypy3.5"
       env: TOX_ENV=pypy3
     - python: "3.6"
       env: TOX_ENV=lint
+    - python: "3.7"
+      env: TOX_ENV=lint
+      dist: xenial
+      sudo: true
+
 cache:
   - pip: true
   - directories:

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,py3}
+    py{35,36,37,py3}
     lint
 
 [flake8]
@@ -17,6 +17,7 @@ deps =
 basepython =
     py35: python3.5
     py36: python3.6
+    py37: python3.7
     pypy3: pypy3
 
 [testenv:lint]


### PR DESCRIPTION
### What was wrong?
Test were not running on python 3.7


### How was it fixed?
Update tox.ini, .travis.yml, setup.py and .circleci/config.yml to run tests on python 3.7


#### Cute Animal Picture

![Cute animal picture](https://hips.hearstapps.com/ghk.h-cdn.co/assets/17/30/pembroke-welsh-corgi.jpg)
