### PR TITLE
Type hints

### DIFF
--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -28,9 +28,6 @@ def get_bloom_bits(value: bytes) -> Iterable[int]:
         yield bloom_bits
 
 
-T = TypeVar('T', bound='BloomFilter')
-
-
 class BloomFilter(numbers.Number):
     value = None
 

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -28,6 +28,9 @@ def get_bloom_bits(value: bytes) -> Iterable[int]:
         yield bloom_bits
 
 
+T = TypeVar('T', bound='BloomFilter')
+
+
 class BloomFilter(numbers.Number):
     value = None
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     extras_require=extras_require,
     license="MIT",
     zip_safe=False,
+    package_data={'eth_bloom': ['py.typed']},
     keywords='ethereum blockchain evm trie merkle',
     packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[


### PR DESCRIPTION
### What was wrong?
The type hinting of `eth-bloom` module needs to be reflected in the setup, for the use of other modules which are importing this module.


### How was it fixed?
`setup.py` file was modified so as to reflect the changes. The file `py.typed` was created, so as to reflect the changes.


#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/qQ5SR0TGSmE/maxresdefault.jpg)
