### PR TITLE
Piper/fix type checker

### DIFF
--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -29,13 +29,16 @@ def get_bloom_bits(value: bytes) -> Iterable[int]:
 
 
 class BloomFilter(numbers.Number):
-    value = None
+    value = None  # type: int
 
     def __init__(self, value: int = 0) -> None:
         self.value = value
 
     def __int__(self) -> int:
         return self.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
 
     def add(self, value: bytes) -> None:
         if not isinstance(value, bytes):
@@ -91,3 +94,7 @@ class BloomFilter(numbers.Number):
 
     def __iadd__(self, other: Union[int, "BloomFilter"]) -> "BloomFilter":
         return self._icombine(other)
+
+
+# This ensures that our linter catches any missing abstract base methods
+__vector = BloomFilter()

--- a/eth_bloom/bloom.py
+++ b/eth_bloom/bloom.py
@@ -5,6 +5,7 @@ import operator
 from typing import (
     Iterable,
     Union,
+    TYPE_CHECKING,
 )
 
 from eth_hash.auto import keccak as keccak_256
@@ -96,5 +97,6 @@ class BloomFilter(numbers.Number):
         return self._icombine(other)
 
 
-# This ensures that our linter catches any missing abstract base methods
-__vector = BloomFilter()
+if TYPE_CHECKING:
+    # This ensures that our linter catches any missing abstract base methods
+    BloomFilter()

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require = {
     ],
     'lint': [
         "flake8>=3.5.0,<4.0.0",
+        'mypy<0.600',
     ],
     'deploy': [
         'bumpversion>=0.5.3,<1.0.0',

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,6 @@ envlist=
 [flake8]
 max-line-length= 100
 exclude= tests/*
-commands=
-	mypy --strict --follow-imports=silent --ignore-missing-imports -p eth_bloom
 
 [testenv]
 usedevelop=True
@@ -26,4 +24,6 @@ basepython =
 [testenv:lint]
 basepython=python
 extras=lint
-commands=flake8 {toxinidir}/eth_bloom {toxinidir}/tests
+commands=
+    flake8 {toxinidir}/eth_bloom {toxinidir}/tests
+    mypy --strict --follow-imports=silent --ignore-missing-imports -p eth_bloom


### PR DESCRIPTION
See https://circleci.com/gh/ethereum/py-evm/124106?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link for why this is needed.

### What was wrong?

- type checking wasn't actually enabled in CI
- the `BloomFilter` class was missing the `__hash__` abstract base method required by the `numbers.Number` abstract base class.

### How was it fixed?

- fixed CI setup
- added a `__hash__` impleentation

#### Cute Animal Picture

![surprised-shocked-animals-funny-32__700](https://user-images.githubusercontent.com/824194/50926902-6f8daa00-1413-11e9-8e5c-18d8c580bec4.jpg)

