### PR TITLE
Update eth hash dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+X.X.X
+--------
+
+* Upgrade `eth-hash` dependency to work with newer `eth-utils`.
+
 0.5.0
 --------
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     py_modules=['eth_bloom'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-hash>=0.1.0a3,<0.3.0",
+        "eth-hash>=0.3.1",
     ],
     python_requires='>=3.5, !=3.5.2, <4',
     extras_require=extras_require,


### PR DESCRIPTION
### Fixes a version conflict with newer eth-utils
The dependency for `eth-hash` was pinned below `0.3.0`. This leads to dependency resolution conflicts if both, `eth-bloom` and `eth-utils` are imported, because `eth-utils` needs `eth-hash >= 0.3.1`.

### How was it fixed?
The dependency pinning for `eth-hash` was upgraded to match `eth-util`s (`>= 0.3.1`).

For a complete fix of #33 this still needs to be released.

#### Cute Animal Picture

![Cute animal picture](https://live.staticflickr.com/939/42949361975_9b957d9873_b.jpg)
