### PR TITLE
Bump eth-hash dependency & drop py3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,9 @@ jobs:
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35
   py36-core:
     <<: *common
     docker:
@@ -59,7 +53,6 @@ workflows:
   test:
     jobs:
       - lint
-      - py35-core
       - py36-core
       - py37-core
       - pypy3-core

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A python implementation of the bloom filter used by Ethereum.
 
 > This library and repository was previously located at https://github.com/pipermerriam/ethereum-bloom.  It was transferred to the Ethereum foundation github in November 2017 and renamed to `eth-bloom`.  The PyPi package was also renamed from `ethereum-bloom` to `eth-bloom.
 
-For more information on what Ethereum Bloom Filters are see [here](what_Is_eth-bloom.txt)
+For more information on what Ethereum Bloom Filters are see [here](what_Is_eth-bloom.txt).
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     py_modules=['eth_bloom'],
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-hash>=0.1.0a3,<0.3.0",
+        "eth-hash[pycryptodome]>=0.3.1,<0.4.0",
     ],
     python_requires='>=3.5, !=3.5.2, <4',
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=[
         "eth-hash[pycryptodome]>=0.3.1,<0.4.0",
     ],
-    python_requires='>=3.5, !=3.5.2, <4',
+    python_requires='>=3.6, <4',
     extras_require=extras_require,
     license="MIT",
     zip_safe=False,
@@ -56,7 +56,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,37,py3}
+    py{36,37,py3}
     lint
 
 [flake8]
@@ -16,7 +16,6 @@ extras=
 deps =
     eth-hash[pycryptodome]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     pypy3: pypy3


### PR DESCRIPTION
### What was wrong?
Fixes #33 
Fixes #35 

From initial investigation, this seems to be the source of a fairly deep dependency conflict. `web3[tester]` won't install properly - which is causing issues with the ethpm-cli docker image. Also, it's been a while since this library was last updated. 

`ERROR: eth-bloom 1.0.3 has requirement eth-hash<0.3.0,>=0.1.0a3, but you'll have eth-hash 0.3.1 which is incompatible.`

Cutting a new release of `eth-bloom` after this pr merge should resolve the dependency conflicts upstream. 

Also dropped support for py3.5


### How was it fixed?
Bumped `eth-hash` dependency.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/115217009-f5255780-a0fc-11eb-95b2-01a2745a35ff.png)
